### PR TITLE
Optional validation start after first change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-dotnet-validator",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-dotnet-validator",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "dist/index.js",
   "module": "index.js",
   "author": {

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,10 @@ This adds a reference to the input field, so the `<validator>` instance knows wh
 
 This adds the model binding in the `<validator>` instance.
 
+`:instant-validation="false"` (optional, default is `true`)
+
+When this is turned off the validation only triggers after the first change (instead of first blur) or on submit of the validator group.
+
 ## Creating custom validators
 It is possible to create your own validators, below is an example of a very simple custom validator.
 
@@ -92,3 +96,11 @@ To use this custom validator in your own form, make sure your custom .NET data a
 ## Custom validators with additional parameters
 You can extend the features of your custom validators using additional data-attributes on your `<input>` tag. This is a feature supported in .NET.
 For an example on the usage of this feature, see `regexvalidator.js`.
+
+## Publish a new version
+Make sure you have publish rights at the Q42 organisation on NPM.
+
+```shell
+npm version [major|minor|patch]
+npm publish
+```

--- a/src/validator-group.js
+++ b/src/validator-group.js
@@ -25,6 +25,8 @@ export default {
                 if(!validator.isValid) {
                     valid = false;
                     event.preventDefault();
+                    validator.hasChanged = true;
+                    validator.showValidationMessage();
                     validator.blurField(); // Force showing validation.
                 }
             });

--- a/src/validator.js
+++ b/src/validator.js
@@ -20,6 +20,10 @@ export default (extraValidators = {}) => {
       // This parameter can be used to provide additional complex validation from your app
       extraErrorMessage: {
         default: ''
+      },
+      instantValidation: {
+        type: Boolean,
+        default: true
       }
     },
     data() {
@@ -100,7 +104,7 @@ export default (extraValidators = {}) => {
           return null;
       },
       blurField(event) {
-        if(event) {
+        if(event && event.target.value !== '') {
           this.val = event.target.value;
         }
         this.blurred = true;
@@ -139,8 +143,8 @@ export default (extraValidators = {}) => {
         });
       },
       showValidationMessage() {
-        if(!this.blurred) {
-          // Only show validation after blur.
+        if((!this.instantValidation && !this.hasChanged) || !this.blurred) {
+          // Only show validation when has changed and instant validation is changed or after blur.
           return;
         }
         this.$refs.message.innerHTML = this.validationMessage;
@@ -175,7 +179,7 @@ export default (extraValidators = {}) => {
             message = validator.getMessage();
           }
         });
-        if(!message && !this.hasChanged) {
+        if(!message && !this.hasChanged && this.instantValidation) {
           // User has not done anything yet, if server-side message is present, show that.
           message = this.$refs.message.innerHTML;
         }


### PR DESCRIPTION
### Changes
It adds an option to turn off the instant validation after blur. When this is turned off the validation starts after the input has been changed.

### Testing
- Add version 0.5.0 to an external project with npm link or install `vue-dotnet-validator@0.5.0`