### PR TITLE
Validation styles

### DIFF
--- a/example.html
+++ b/example.html
@@ -133,6 +133,22 @@
                     <input name="field8" type="text" asp-for="stuff" ref="field" v-model="val" data-val-required="This value is required." data-val-equalto="Must be equal to the previous input!" data-val-equalto-other="*.field7"/>
                 </label>
             </validator>
+
+	        <validator validation-style="after-change" inline-template>
+		        <label>
+			        <span asp-validation-for="stuff" ref="message" class="message"></span>
+			        <span>After change</span>
+			        <input name="field9" type="text" asp-for="stuff" ref="field" v-model="val" data-val-required="This value is required."/>
+		        </label>
+	        </validator>
+
+	        <validator validation-style="after-blur" inline-template>
+		        <label>
+			        <span asp-validation-for="stuff" ref="message" class="message"></span>
+			        <span>After blur</span>
+			        <input name="field10" type="text" asp-for="stuff" ref="field" v-model="val" data-val-required="This value is required."/>
+		        </label>
+	        </validator>
             <button type="submit">Register</button>
         </form>
     </vue-dotnet-validator-group>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-dotnet-validator",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-dotnet-validator",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "module": "index.js",
   "author": {

--- a/readme.md
+++ b/readme.md
@@ -66,9 +66,11 @@ This adds a reference to the input field, so the `<validator>` instance knows wh
 
 This adds the model binding in the `<validator>` instance.
 
-`:instant-validation="false"` (optional, default is `true`)
+`validation-style=""` (optional, default is `after-blur`), validation-styles:
 
-When this is turned off the validation only triggers after the first change (instead of first blur) or on submit of the validator group.
+- `after-blur` (default): After first blur validation will be reactive.
+- `after-change`: After first change validation will be reactive, blurring a autofocus field with no input will not trigger this.
+- `after-submit`: After first submit validation will be reactive.
 
 ## Creating custom validators
 It is possible to create your own validators, below is an example of a very simple custom validator.

--- a/src/validator-group.js
+++ b/src/validator-group.js
@@ -21,12 +21,12 @@ export default {
     methods: {
         validate(event) {
             let valid = true;
-            this.validators.forEach(validator => {
+            this.validators.forEach(async (validator) => {
+                validator.hasForced = true;
                 if(!validator.isValid) {
                     valid = false;
                     event.preventDefault();
-                    validator.hasChanged = true;
-                    validator.showValidationMessage();
+                    validator.showValidationMessage(true);
                     validator.blurField(); // Force showing validation.
                 }
             });

--- a/src/validator-group.js
+++ b/src/validator-group.js
@@ -21,7 +21,7 @@ export default {
     methods: {
         validate(event) {
             let valid = true;
-            this.validators.forEach(async (validator) => {
+            this.validators.forEach(validator => {
                 validator.hasForced = true;
                 if(!validator.isValid) {
                     valid = false;

--- a/src/validator.js
+++ b/src/validator.js
@@ -8,9 +8,9 @@ export default (extraValidators = {}) => {
   }
   
   const validationStyles = {
-      afterBlur: 'after-blur', // default
-      afterChange: 'after-change',
-      afterSubmit: 'after-submit'
+    afterBlur: 'after-blur', // default
+    afterChange: 'after-change',
+    afterSubmit: 'after-submit'
   } 
 
   const validClass = 'field-validation-valid';


### PR DESCRIPTION
### Changes
It adds 3 validation styles

`validation-style=""` (optional, default is `after-blur`), validation-styles:

- `after-blur` (default): After first blur validation will be reactive.
- `after-change`: After first change validation will be reactive, blurring a autofocus field with no input will not trigger this.
- `after-submit`: After first submit validation will be reactive.

### Testing
Add to an external project with npm link.

### Todo
- [ ] Publish beta
- [x] Publish release